### PR TITLE
Call it Watchdog or Wachhund, but not Wachdog

### DIFF
--- a/lib/translations.js
+++ b/lib/translations.js
@@ -389,7 +389,7 @@ const translations = {
 	},
 	Instance_Watchdog: {
 		en: 'Instance Watchdog',
-		de: 'Instanz-Wachdog',
+		de: 'Instanz-Watchdog',
 		ru: 'Слежение за экземпляром',
 		pt: 'Watchdog de Instância',
 		nl: 'Instance-Wachdog',


### PR DESCRIPTION
Instanz-Wachdog is strange, either translate it to Wachhund or keep it with Watchdog.