### PR TITLE
Remove remaining horizontal rules from HTML tables

### DIFF
--- a/lib/crud.js
+++ b/lib/crud.js
@@ -785,9 +785,6 @@ async function createListHTML(adaptr, type, devices, deviceCount, isLowBatteryLi
 			<th align=left>${[translations.Device[adaptr.config.userSelectedLanguage]]}</th>
 			<th align=center width=120>${[translations.Adapter[adaptr.config.userSelectedLanguage]]}</th>
 			<th align=center>${[translations.Last_Contact[adaptr.config.userSelectedLanguage]]}</th>
-			</tr>
-			<tr>
-			<td colspan="5"><hr></td>
 			</tr>`;
 
 			for (const device of devices) {
@@ -817,9 +814,6 @@ async function createListHTML(adaptr, type, devices, deviceCount, isLowBatteryLi
 			<th align=left>${[translations.Device[adaptr.config.userSelectedLanguage]]}</th>
 			<th align=center width=120>${[translations.Adapter[adaptr.config.userSelectedLanguage]]}</th>
 			<th align=${isLowBatteryList ? 'center' : 'right'}>${[translations.Battery[adaptr.config.userSelectedLanguage]]}</th>
-			</tr>
-			<tr>
-			<td colspan="5"><hr></td>
 			</tr>`;
 			for (const device of devices) {
 				html += `<tr>
@@ -864,9 +858,6 @@ async function createListHTMLInstances(adaptr, type, instances, instancesCount) 
 				<th align=left>${[translations.Adapter[adaptr.config.userSelectedLanguage]]}</th>
 				<th align=center>${[translations.Instance[adaptr.config.userSelectedLanguage]]}</th>
 				<th align=center width=180>${[translations.Status[adaptr.config.userSelectedLanguage]]}</th>
-				</tr>
-				<tr>
-				<td colspan="5"><hr></td>
 				</tr>`;
 
 			for (const instanceData of instances) {
@@ -895,9 +886,6 @@ async function createListHTMLInstances(adaptr, type, instances, instancesCount) 
 				<th align=left>${[translations.Adapter[adaptr.config.userSelectedLanguage]]}</th>
 				<th align=center>${[translations.Instance[adaptr.config.userSelectedLanguage]]}</th>
 				<th align=center width=180>${[translations.Status[adaptr.config.userSelectedLanguage]]}</th>
-				</tr>
-				<tr>
-				<td colspan="5"><hr></td>
 				</tr>`;
 
 			for (const instanceData of instances) {
@@ -926,9 +914,6 @@ async function createListHTMLInstances(adaptr, type, instances, instancesCount) 
 				<th align=left>${[translations.Adapter[adaptr.config.userSelectedLanguage]]}</th>
 				<th align=center>${[translations.Instance[adaptr.config.userSelectedLanguage]]}</th>
 				<th align=center width=180>${[translations.Status[adaptr.config.userSelectedLanguage]]}</th>
-				</tr>
-				<tr>
-				<td colspan="5"><hr></td>
 				</tr>`;
 
 			for (const instanceData of instances) {
@@ -957,9 +942,6 @@ async function createListHTMLInstances(adaptr, type, instances, instancesCount) 
 				<th align=left>${[translations.Adapter[adaptr.config.userSelectedLanguage]]}</th>
 				<th align=center>${[translations.Instance[adaptr.config.userSelectedLanguage]]}</th>
 				<th align=center width=180>${[translations.Status[adaptr.config.userSelectedLanguage]]}</th>
-				</tr>
-				<tr>
-				<td colspan="5"><hr></td>
 				</tr>`;
 
 			for (const instanceData of instances) {
@@ -985,9 +967,6 @@ async function createListHTMLInstances(adaptr, type, instances, instancesCount) 
 				<th align=left>${[translations.Adapter[adaptr.config.userSelectedLanguage]]}</th>
 				<th align=center>${[translations.Installed_Version[adaptr.config.userSelectedLanguage]]}</th>
 				<th align=center>${[translations.Available_Version[adaptr.config.userSelectedLanguage]]}</th>
-				</tr>
-				<tr>
-				<td colspan="5"><hr></td>
 				</tr>`;
 
 			for (const instanceData of instances.values()) {

--- a/lib/crud.test.js
+++ b/lib/crud.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/* global describe, it */
+
+const assert = require('node:assert/strict');
+const { createListHTML, createListHTMLInstances } = require('./crud');
+
+describe('HTML list generation', () => {
+	const adapter = {
+		config: {
+			userSelectedLanguage: 'en',
+		},
+	};
+
+	const deviceListTypes = ['linkQualityList', 'offlineList', 'batteryList'];
+	const instanceListTypes = [
+		'allInstancesList',
+		'allActiveInstancesList',
+		'errorInstanceList',
+		'deactivatedInstanceList',
+		'updateAdapterList',
+	];
+
+	for (const type of deviceListTypes) {
+		it(`does not add a horizontal rule to ${type}`, async () => {
+			const html = await createListHTML(adapter, type, [], 0, false);
+
+			assert.doesNotMatch(html, /<hr\b/i);
+		});
+	}
+
+	for (const type of instanceListTypes) {
+		it(`does not add a horizontal rule to ${type}`, async () => {
+			const instances = type === 'updateAdapterList' ? new Map() : [];
+			const html = await createListHTMLInstances(adapter, type, instances, 0);
+
+			assert.doesNotMatch(html, /<hr\b/i);
+		});
+	}
+});


### PR DESCRIPTION
Follow-up to #679 for #674.

The first fix removed the separator row from `linkQualityList`, but seven copies remained in the other device and instance table templates.

- Remove the remaining `<hr>` rows from all generated HTML tables
- Add regression coverage for every device and instance list variant

Tests:
- `npm test`
- `npm run lint` (passes with existing warnings)